### PR TITLE
Smaller docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.venv
+venv
+tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,6 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 COPY defi_repertoire ./defi_repertoire
 
 ENV PYTHONPATH=.
+ENV PORT=8000
 
-CMD ["uvicorn", "defi_repertoire.main:app", "--workers", "4"]
+CMD uvicorn defi_repertoire.main:app --workers=4 --host=0.0.0.0 --port=${PORT} --loop=asyncio --no-use-colors

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi<=0.111.0
 uvicorn[standard]
-rolesroyce[all] @ git+https://github.com/Karpatkey/roles_royce.git@a3d1a073748c99389f18fe465e8c8f34c0929160
+rolesroyce @ git+https://github.com/karpatkey/roles_royce.git@3a5d92af6d3124052d41373d2a5a20f46d75d562
+karpatkit @ git+https://github.com/karpatkey/karpatkit.git


### PR DESCRIPTION
- Set karpatkit dependency directly and point it to latest until new version is released with NATIVE token
- Improved dockerfile with cache layers for deps and reducing container image from ~600MB to ~250MB